### PR TITLE
Fix issue where popover fails to close if it starts out as open

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ const Popover = createClass({
       standing: `below`,
       exited: !this.props.isOpen, // for animation-dependent rendering, should popover close/open?
       exiting: false, // for tracking in-progress animations
-      toggle: false, // for business logic tracking, should popover close/open?
+      toggle: this.props.isOpen || false, // for business logic tracking, should popover close/open?
     }
   },
   componentDidMount () {


### PR DESCRIPTION
This component has the same issue as described here https://github.com/littlebits/react-popover/issues/83 
The fix is the same as they applied https://github.com/littlebits/react-popover/pull/97